### PR TITLE
Add web.dev

### DIFF
--- a/background.js
+++ b/background.js
@@ -30,7 +30,7 @@ const AD_DOMAINS = [
 ];
 
 const DEVELOPER_DOMAINS = [
-  "madewithcode.com", "design.google", "gallery.io", "domains.google", "material.io", "android.com", "chromium.org", "cobrasearch.com", "chromecast.com", "chrome.com", "chromebook.com", "madewithcode.com", "whatbrowser.org", "withgoogle.com",
+  "madewithcode.com", "design.google", "gallery.io", "domains.google", "material.io", "android.com", "chromium.org", "cobrasearch.com", "chromecast.com", "chrome.com", "chromebook.com", "madewithcode.com", "whatbrowser.org", "withgoogle.com", "web.dev",
 ];
 
 


### PR DESCRIPTION
<https://web.dev> is a new site launched by Google for website developers. (fixes #33 )