### PR TITLE
Add options to ignore YouTube and Google Search Pages

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -26,10 +26,16 @@
         "management",
         "tabs",
         "webRequestBlocking",
-        "webRequest"
+        "webRequest",
+        "storage"
     ],
 
     "background": {
         "scripts": ["background.js"]
+    },
+    
+    "options_ui": {
+        "page": "options.html",
+        "browser_style": true
     }
 }

--- a/options.html
+++ b/options.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+
+<html>
+
+<head>
+	<meta charset="utf-8">
+</head>
+
+<body>
+	<form>
+	
+		<p>
+			<label>
+				<input type="checkbox" id="ignore_youtube" value="1">
+				Ignore YouTube
+			</label>
+		</p>
+		
+		<p>
+			<label>
+				<input type="checkbox" id="ignore_searchpages" value="1">
+				Ignore search pages
+			</label>
+		</p>
+
+		<button type="submit">Save settings</button>
+		
+	</form>
+	<script src="options.js"></script>
+</body>
+
+</html>

--- a/options.html
+++ b/options.html
@@ -9,21 +9,29 @@
 <body>
 	<form>
 	
+		<h1>Settings</h1>
+		
+		<hr>
+		
 		<p>
 			<label>
 				<input type="checkbox" id="ignore_youtube" value="1">
-				Ignore YouTube
+				Ignore YouTube<br>
+				<em>(Means don't use Google Container for YouTube sites.)<em>
 			</label>
 		</p>
 		
 		<p>
 			<label>
 				<input type="checkbox" id="ignore_searchpages" value="1">
-				Ignore search pages
+				Ignore search pages<br>
+				<em>(Means don't use Google Container on Google sites with a path of <code>/search</code>, <code>/maps</code> or <code>/flights</code>.)<em>
 			</label>
 		</p>
 
 		<button type="submit">Save settings</button>
+		
+		<hr>
 		
 	</form>
 	<script src="options.js"></script>

--- a/options.js
+++ b/options.js
@@ -1,0 +1,26 @@
+function onOptionsPageSave(e)
+{
+	e.preventDefault();
+
+	// Save settings
+	browser.storage.sync.set({
+		"ignore_youtube": document.querySelector("#ignore_youtube").checked,
+		"ignore_searchpages": document.querySelector("#ignore_searchpages").checked
+	});
+
+	browser.runtime.reload();
+}
+
+function onOptionsPageLoaded()
+{
+	// Load saved settings or use defaults when nothing was saved yet
+	var storageItem = browser.storage.sync.get();
+	storageItem.then((res) =>
+	{
+		document.querySelector("#ignore_youtube").checked = res.ignore_youtube || false;
+		document.querySelector("#ignore_searchpages").checked = res.ignore_searchpages || false;
+	});
+}
+
+document.addEventListener("DOMContentLoaded", onOptionsPageLoaded);
+document.querySelector("form").addEventListener("submit", onOptionsPageSave);


### PR DESCRIPTION
First: Thanks for this great Firefox extension! :)

I wanted to have two additions to fit what I wanted:
- Ignore YouTube - I don't want to be logged into Google when using YouTube
- Ignore Search Pages - I don't want to be logged into Google for searches (includes Maps and Flights search)

The first was already done by hard removing the `YOUTUBE_DOMAINS`: [Repo](https://github.com/yoasif/contain-google-minus-youtube) & [AMO AddOn](https://addons.mozilla.org/de/firefox/addon/google-container-minus-youtube/)

The later I did today by also hard coding this (done by URL path matching): [Repo](https://github.com/berrnd/contain-google-minus-youtube-and-searchpages/tree/master) & [AMO AddOn](https://addons.mozilla.org/de/firefox/addon/google-container-minus-yt-srch/)

I thought maybe this is useful for others too and added both things in an optional way.

Technically this maybe could be done better, but I found no proper way to do it right:
- When ignoring YouTube, it would be enough to exclude the YouTube domains when concating all domains together at the top of the script
- The path match for excluding search pages should be maybe better limited to `GOOGLE_DOMAINS` and `GOOGLE_INTL_DOMAINS`, currently checks all domains

(But it works... :D)