### PR TITLE
Fix for Issue #57

### DIFF
--- a/background.js
+++ b/background.js
@@ -234,10 +234,14 @@ function reopenTab ({url, tab, cookieStoreId}) {
     url,
     cookieStoreId,
     active: tab.active,
-    index: tab.index,
+    index: tab.index + 1,
     windowId: tab.windowId
   });
-  browser.tabs.remove(tab.id);
+  // We do not want to erase google container if going from 
+  // google container back to default.
+  if (cookieStoreId != "firefox-default") {
+    browser.tabs.remove(tab.id);
+  }
 }
 
 function isGoogleURL (url) {

--- a/background.js
+++ b/background.js
@@ -239,7 +239,7 @@ function reopenTab ({url, tab, cookieStoreId}) {
   });
   // We do not want to erase google container if going from 
   // google container back to default.
-  if (cookieStoreId != "firefox-default") {
+  if (!(isSearchPageURL(tab.url))) {
     browser.tabs.remove(tab.id);
   }
 }


### PR DESCRIPTION
Fix for contain-google issue #57 . 

When leaving the google container on a link that does not open a new tab, the original tab is deleted.

See behavior gifs in the Issue. New behavior is that the link is opened in a new tab and the old tab is not removed.

This fix only works for searches, but I think that's where this issue is popping up the most.