### PR TITLE
Fixed lacking backslash in RegExp

### DIFF
--- a/background.js
+++ b/background.js
@@ -153,11 +153,11 @@ function generateGoogleHostREs () {
 
   for (let googleDomain of GOOGLE_DOMAINS) {
     googleDomain = googleDomain.replace(matchOperatorsRegex, '\\$&');
-    googleHostREs.push(new RegExp(`(^|\.)${googleDomain}$`));
+    googleHostREs.push(new RegExp(`(^|\\.)${googleDomain}$`));
   }
   for (let youtubeDomain of YOUTUBE_DOMAINS) {
     youtubeDomain = youtubeDomain.replace(matchOperatorsRegex, '\\$&');
-    youtubeHostREs.push(new RegExp(`(^|\.)${youtubeDomain}$`));
+    youtubeHostREs.push(new RegExp(`(^|\\.)${youtubeDomain}$`));
   }
 }
 


### PR DESCRIPTION
Fixes the issue with domains containing the keywords but not belonging to Google (like nomoregoogle.com) being opened in containers