### PR TITLE
Added the option to ignore /preferences (and /setprefs) pages to be able to customize search results (e.g. setting the language) when ignoring /search pages

### DIFF
--- a/background.js
+++ b/background.js
@@ -237,7 +237,7 @@ function reopenTab ({url, tab, cookieStoreId}) {
     index: tab.index + 1,
     windowId: tab.windowId
   });
-  // We do not want to erase google container if going from 
+  // We do not want to erase google container if going from
   // google container back to default.
   if (!(isSearchPageURL(tab.url))) {
     browser.tabs.remove(tab.id);
@@ -269,6 +269,16 @@ function isSearchPageURL (url) {
   return parsedUrl.pathname.startsWith('/search');
 }
 
+function isPrefPageURL (url) {
+  const parsedUrl = new URL(url);
+  return parsedUrl.pathname.startsWith('/preferences');
+}
+
+function isSetprefsPageURL (url) {
+  const parsedUrl = new URL(url);
+  return parsedUrl.pathname.startsWith('/setprefs');
+}
+
 function isMapsURL (url) {
   const parsedUrl = new URL(url);
   return parsedUrl.pathname.startsWith('/maps');
@@ -295,6 +305,14 @@ function shouldContainInto (url, tab) {
     handleUrl = false;
   }
 
+  if (handleUrl && extensionSettings.ignore_prefpages && isPrefPageURL(url)) {
+    handleUrl = false;
+  }
+
+  if (handleUrl && extensionSettings.ignore_prefpages && isSetprefsPageURL(url)) {
+    handleUrl = false;
+  }
+
   if (handleUrl && extensionSettings.ignore_maps && isMapsURL(url)) {
     handleUrl = false;
   }
@@ -309,7 +327,7 @@ function shouldContainInto (url, tab) {
         // Tab is already in a container, the user doesn't want us to override containers
         return false;
       }
-      
+
       // Google-URL outside of Google Container Tab
       // Should contain into Google Container
       return googleCookieStoreId;

--- a/options.html
+++ b/options.html
@@ -32,6 +32,14 @@
 
 		<p>
 			<label>
+				<input type="checkbox" id="ignore_prefpages" value="1">
+				Ignore preference pages<br>
+				<em>(Means don't use Google Container on Google sites with a path of <code>/preferences</code> and <code>/setprefs</code>. Useful when ignoring search pages to still be able to change search language.)</em>
+			</label>
+		</p>
+
+		<p>
+			<label>
 				<input type="checkbox" id="ignore_maps" value="1">
 				Ignore maps pages<br>
 				<em>(Means don't use Google Container on Google sites with a path of <code>/maps</code>.)</em>
@@ -45,7 +53,7 @@
 				<em>(Means don't use Google Container on Google sites with a path of <code>/flights</code>.)</em>
 			</label>
 		</p>
-		
+
 		<p>
 			<label>
 				<input type="checkbox" id="dont_override_containers" value="1">

--- a/options.js
+++ b/options.js
@@ -6,6 +6,7 @@ function onOptionsPageSave(e)
 	browser.storage.sync.set({
 		"ignore_youtube": document.querySelector("#ignore_youtube").checked,
 		"ignore_searchpages": document.querySelector("#ignore_searchpages").checked,
+		"ignore_prefpages": document.querySelector("#ignore_prefpages").checked,
 		"ignore_maps": document.querySelector("#ignore_maps").checked,
 		"ignore_flights": document.querySelector("#ignore_flights").checked,
 		"dont_override_containers": document.querySelector("#dont_override_containers").checked
@@ -22,6 +23,7 @@ function onOptionsPageLoaded()
 	{
 		document.querySelector("#ignore_youtube").checked = res.ignore_youtube || false;
 		document.querySelector("#ignore_searchpages").checked = res.ignore_searchpages || false;
+		document.querySelector("#ignore_prefpages").checked = res.ignore_prefpages || false;
 		document.querySelector("#ignore_maps").checked = res.ignore_maps || false;
 		document.querySelector("#ignore_flights").checked = res.ignore_flights || false;
 		document.querySelector("#dont_override_containers").checked = res.override_containers || false;


### PR DESCRIPTION
@dawnarius [requested](https://github.com/containers-everywhere/contain-google/issues/82) the option to ignore /preferences to be able to customize search results when ignoring /search pages.

I've also included /setprefs to the option as it allows to change the language directly from the little pop-up asking if you would like to see results in a certain language (I assume based on search terms language or browsing history).