### PR TITLE
Fix whitelist option breaking when not previously set.

### DIFF
--- a/background.js
+++ b/background.js
@@ -173,6 +173,9 @@ function generateWhitelistedHostREs () {
 
 async function loadExtensionSettings () {
   extensionSettings = await browser.storage.sync.get();
+  if (extensionSettings.whitelist === undefined){
+ 	extensionSettings.whitelist = "";
+  }
 }
 
 async function clearGoogleCookies () {

--- a/options.js
+++ b/options.js
@@ -14,7 +14,7 @@ function validate_whitelist() {
 }
 
 function fill_whitelist_option(stored_whitelist) {
-    whitelist_text = stored_whitelist.join("\n");
+    whitelist_text = (stored_whitelist === undefined) ? "" : stored_whitelist.join("\n");
     document.querySelector("#whitelist").value = whitelist_text ? whitelist_text : "";
 }
 


### PR DESCRIPTION
This should fix the breaking of containment introduced by #108.
When a user has not set a whitelist option, the whitelist variable will be undefined and should default to empty strings.