### PR TITLE
update domain list

### DIFF
--- a/background.js
+++ b/background.js
@@ -6,7 +6,7 @@ const GOOGLE_CONTAINER_ICON = "briefcase";
 let GOOGLE_DOMAINS = [
   "google.com", "google.org", "googleapis.com", "g.co", "ggpht.com", "gle",
   "blogger.com", "googleblog.com", "blog.google", "googleusercontent.com", "googlesource.com",
-  "google.org", "google.net", "466453.com", "gooogle.com", "gogle.com", "ggoogle.com", "gogole.com", "goolge.com", "googel.com", "googlee.com", "googil.com", "googlr.com", "elgoog.im", "ai.google", "com.google", "about.google", "registry.google", "google", "gstatic.com"
+  "google.org", "google.net", "466453.com", "gooogle.com", "gogle.com", "ggoogle.com", "gogole.com", "goolge.com", "googel.com", "googlee.com", "googil.com", "googlr.com", "elgoog.im", "ai.google", "com.google", "about.google", "registry.google", "google", "gstatic.com", "goog"
 ];
 
 const GOOGLE_INTL_DOMAINS = [


### PR DESCRIPTION
Google Translate is using the goog top level domain. For example if you go to [vnexpress.net](https://translate.google.com/translate?hl=&sl=vi&tl=en&u=https%3A%2F%2Fvnexpress.net%2Fthu-tuong-dong-y-gian-cach-xa-hoi-mot-so-khu-vuc-o-tp-hcm-4233454.html) in google translate and open in of the page links in a new page it will go to a url with that is a subdomain of translate.goog .

## Expected behavior
The new tab opens in a google container

## Current Behavior

The tab does not open in a google container

## Fix
I added `goog` to the list of google domains. 