### PR TITLE
Don't force allowlisted URLs into Google Container

### DIFF
--- a/background.js
+++ b/background.js
@@ -343,7 +343,8 @@ function shouldContainInto (url, tab) {
     return false;
   }
 
-  let handleUrl = isGoogleURL(url) || (extensionSettings.allowlist.length!=0 && isAllowlistedURL(url));
+  let allowlistUrl = (extensionSettings.allowlist.length!=0 && isAllowlistedURL(url));
+  let handleUrl = isGoogleURL(url) || allowlistUrl;
 
   if (handleUrl && extensionSettings.whitelist.length!=0 && isWhitelistedURL(url)) {
     handleUrl = false;
@@ -377,6 +378,11 @@ function shouldContainInto (url, tab) {
     if (tab.cookieStoreId !== googleCookieStoreId) {
       if (tab.cookieStoreId !== "firefox-default" && extensionSettings.dont_override_containers) {
         // Tab is already in a container, the user doesn't want us to override containers
+        return false;
+      }
+
+      if (allowlistUrl) {
+        // Don't force an allowlisted URL to be in the Google Container
         return false;
       }
 


### PR DESCRIPTION
This PR is to propose a fix for #133.

There are some SSO domains that I also use in a different container – I want the allowlist to allow those domains to be accessed from the Google Container, but not switch containers if the domains are accessed elsewhere. I don't want to use the "don't override containers" option as I find overriding Google domains from other containers still useful.

My current workaround is to add the SSO domains to the allowlist whenever Google requires SSO auth, log in on the Google Container using the SSO domains, then remove them from the list. This is annoying as it occurs ~weekly.

The fix I'm proposing here is simply to not force allowlisted URLs to be opened in the Google Container. However, another approach would be to add a "soft allowlist" for such URLs. (Though the "soft allowlist" is more in line with my expectations for an allowlist than the current "allowlist", which mandates inclusion).