### PR TITLE
Add support for .youtube gTLD

### DIFF
--- a/background.js
+++ b/background.js
@@ -18,7 +18,7 @@ const GOOGLE_SERVICES = [
 ];
 
 const YOUTUBE_DOMAINS = [
-  "youtube.com", "youtu.be", "yt.be", "ytimg.com", "youtube-nocookie.com", "youtubegaming.com", "youtubeeducation.com",
+  "youtube.com", "youtu.be", "yt.be", "ytimg.com", "youtube-nocookie.com", "youtubegaming.com", "youtubeeducation.com", "youtube",
 ];
 
 const BLOGSPOT_DOMAINS = [


### PR DESCRIPTION
Change
- `"youtube"` has been added to `YOUTUBE_DOMAINS`

Reason
- .google, .goog., and .gle gTLDs are already handled, however .youtube gTLD sites are not. (ex: https://blog.youtube/ and https://about.youtube)