### PR TITLE
Add google search-console to the list of domains

### DIFF
--- a/background.js
+++ b/background.js
@@ -14,7 +14,7 @@ const GOOGLE_INTL_DOMAINS = [
 ];
 
 const GOOGLE_SERVICES = [
-"like.com", "keyhole.com", "panoramio.com", "picasa.com", "urchin.com", "igoogle.com", "foofle.com", "froogle.com", "localguidesconnect.com", "googlemail.com", "googleanalytics.com", "google-analytics.com", "googletagmanager.com", "googlecode.com", "googlesource.com", "googledrive.com", "googlearth.com", "googleearth.com", "googlemaps.com", "googlepagecreator.com", "googlescholar.com", "advertisercommunity.com", "thinkwithgoogle.com", "googlegroups.com",
+"like.com", "keyhole.com", "panoramio.com", "picasa.com", "urchin.com", "igoogle.com", "foofle.com", "froogle.com", "localguidesconnect.com", "googlemail.com", "googleanalytics.com", "google-analytics.com", "googletagmanager.com", "googlecode.com", "googlesource.com", "googledrive.com", "googlearth.com", "googleearth.com", "googlemaps.com", "googlepagecreator.com", "googlescholar.com", "advertisercommunity.com", "thinkwithgoogle.com", "googlegroups.com", "search.google.com/search-console",
 ];
 
 const YOUTUBE_DOMAINS = [
@@ -315,7 +315,7 @@ function isAllowlistedURL (url) {
 
 function isSearchPageURL (url) {
   const parsedUrl = new URL(url);
-  return parsedUrl.pathname.startsWith('/search');
+  return !!parsedUrl.pathname.match(/^\/search$/) && !!parsedUrl.search;
 }
 
 function isPrefPageURL (url) {


### PR DESCRIPTION
This PR adds a new domain to the list of Google Services and respects `Ignore search pages` option too that will cause a conflict because of this new addition. 

search.google.com/search-console is a google services domain for webmasters
I didn't add it as `search.google.com` because that redirects to google homepage. 

As per the current behavior any pathname that starts with `/search` will be included in ignore or allow list based on the user preference of `Ignore search pages` as the new domain's pathname starts with `/search`

So this fix to the isSearchpageURL makes sure that its 
a) pathname exactly matches `/search`
b) has something in `search` params. 

Closes #124 